### PR TITLE
Fix for "Per User" scope for guest purchases

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -36,6 +36,8 @@ function edd_pl_get_file_purchases( $download_id = 0, $price_id = 0, $user_email
 
 	// Override global search if site-wide isn't selected
 	if( $scope != 'site-wide' ) {
+        if( !is_user_logged_in() ) return 0;
+
 		if( ! $user_email ) {
 			$current_user = wp_get_current_user();
 		}


### PR DESCRIPTION
Hello,

we have the purchases enabled for guest users and when using your plugin the "Per User" scope, it thinks the guest user has made some purchases already which is not true of course.

It fails in edd_pl_get_file_purchases() where EDD_Payments_Query() gets empty $query_args['s'] as obviosly the guest user has no email address.

Our fix is to let edd_pl_get_file_purchases() return zero purchases if the scope is set to "Per User" and the user is not logged in.

Thanks,
Martin,